### PR TITLE
Add AGP 8 Namespace for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,28 +1,20 @@
 group 'dev.darttools.flutter_android_volume_keydown'
 version '1.0'
+plugins {
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
-    }
+    /**
+     * Use `apply false` in the top-level build.gradle file to add a Gradle
+     * plugin as a build dependency but not apply it to the current (root)
+     * project. Don't use `apply false` in sub-projects. For more information,
+     * see Applying external plugins with same version to subprojects.
+     */
+    id 'com.android.application' version '8.5.0'
+    id 'com.android.library' version '8.5.0'
+    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
 }
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
     namespace "dev.darttools.flutter_android_volume_keydown"
 
     compileOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,6 @@ plugins {
      */
     id 'com.android.application' version '8.5.0'
     id 'com.android.library' version '8.5.0'
-    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
 }
 
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 30
+    namespace "dev.darttools.flutter_android_volume_keydown"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,39 @@
+pluginManagement {
+
+    /**
+      * The pluginManagement.repositories block configures the
+      * repositories Gradle uses to search or download the Gradle plugins and
+      * their transitive dependencies. Gradle pre-configures support for remote
+      * repositories such as JCenter, Maven Central, and Ivy. You can also use
+      * local repositories or define your own remote repositories. The code below
+      * defines the Gradle Plugin Portal, Google's Maven repository,
+      * and the Maven Central Repository as the repositories Gradle should use to look for its
+      * dependencies.
+      */
+
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+
+    /**
+      * The dependencyResolutionManagement.repositories
+      * block is where you configure the repositories and dependencies used by
+      * all modules in your project, such as libraries that you are using to
+      * create your application. However, you should configure module-specific
+      * dependencies in each module-level build.gradle file. For new projects,
+      * Android Studio includes Google's Maven repository and the Maven Central
+      * Repository by default, but it does not configure any dependencies (unless
+      * you select a template that requires some).
+      */
+
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 rootProject.name = 'flutter_android_volume_keydown'

--- a/android/src/main/java/dev/darttools/flutter_android_volume_keydown/desktop.ini
+++ b/android/src/main/java/dev/darttools/flutter_android_volume_keydown/desktop.ini
@@ -1,2 +1,0 @@
-[.ShellClassInfo]
-LocalizedResourceName=flutter_android_volume_keydown


### PR DESCRIPTION
Android Gradle Plugin 8 now requires all Gradle projects to include a namespace. This resolves that